### PR TITLE
Remove static keyword from pd2zd test method

### DIFF
--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestPD2ED.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestPD2ED.java
@@ -462,7 +462,7 @@ public class TestPD2ED extends TestED2PD
     }
     
     // Non zero packed decimal offset
-    public static void testConvertEmbeddedTrailingNonZeroPackedDecimalOffset() {
+    public void testConvertEmbeddedTrailingNonZeroPackedDecimalOffset() {
         final byte[] input = { (byte) 0x91, (byte) 0x23, (byte) 0x45, (byte) 0x67, (byte) 0x89, (byte) 0x10, (byte) 0x11, (byte) 0x12, (byte) 0x13, (byte) 0x4D };
 
         // Non zero offset ending on the sign byte.


### PR DESCRIPTION
Test method `testConvertEmbeddedTrailingNonZeroPackedDecimalOffset`
shouldn't be static.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>