### PR TITLE
AArch64 macOS: Exclude JVMTI tests in SharedClassesAPI

### DIFF
--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2021 IBM Corp. and others
+* Copyright (c) 2016, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -211,7 +211,9 @@ public class SharedClassesAPI implements SharedClassesPluginInterface {
 			} else {
 				// Temporarily excluding the native tests from running on Windows 
 				//    due to: https://github.com/eclipse-openj9/openj9-systemtest/issues/38 
-				if ( !PlatformFinder.isWindows() ) {
+				// Temporarily excluding the native tests from running on AArch64 macOS
+				//    due to: https://github.com/eclipse-openj9/openj9/issues/14390
+				if ( !PlatformFinder.isWindows() && !PlatformFinder.getPlatformAsString().equals("osx_arm-64") ) {
 					// Verify caches using a JVMTI native agent
 					String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
 					String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";


### PR DESCRIPTION
This commit excludes JVMTI tests in SharedClassesAPI on AArch64 macOS
for the time being, because JVMTI support is not fully working yet on
that platform.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>