### PR TITLE
AArch64 macOS: Enable JVMTI tests in SharedClassesAPI

### DIFF
--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
@@ -211,9 +211,7 @@ public class SharedClassesAPI implements SharedClassesPluginInterface {
 			} else {
 				// Temporarily excluding the native tests from running on Windows 
 				//    due to: https://github.com/eclipse-openj9/openj9-systemtest/issues/38 
-				// Temporarily excluding the native tests from running on AArch64 macOS
-				//    due to: https://github.com/eclipse-openj9/openj9/issues/14390
-				if ( !PlatformFinder.isWindows() && !PlatformFinder.getPlatformAsString().equals("osx_arm-64") ) {
+				if ( !PlatformFinder.isWindows() ) {
 					// Verify caches using a JVMTI native agent
 					String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
 					String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";


### PR DESCRIPTION
This commit reverts the change in #141, to enable JVMTI tests in
SharedClassesAPI on AArch64 macOS back again.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>