### PR TITLE
Reference openjdk.org instead of openjdk.java.net

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -14,7 +14,7 @@
 # OpenJDK Assembly Exception [2].
 #
 # [1] https://www.gnu.org/software/classpath/license.html
-# [2] http://openjdk.java.net/legal/assembly-exception.html
+# [2] https://openjdk.org/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 

--- a/.gitattributes.zos
+++ b/.gitattributes.zos
@@ -1,5 +1,5 @@
 #################################################################################
-# Copyright (c) 2017 IBM Corp.
+# Copyright (c) 2017, 2023 IBM Corp.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 # version 2 with the OpenJDK Assembly Exception [2].
 #
 # [1] https://www.gnu.org/software/classpath/license.html
-# [2] http://openjdk.java.net/legal/assembly-exception.html
+# [2] https://openjdk.org/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #################################################################################

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2021 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.build/build.xml
+++ b/openj9.build/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.build/docs/build.md
+++ b/openj9.build/docs/build.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2021 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.build/makefile
+++ b/openj9.build/makefile
@@ -1,5 +1,5 @@
 #################################################################################
-# Copyright (c) 2017, 2021 IBM Corp.
+# Copyright (c) 2017, 2023 IBM Corp.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 # version 2 with the OpenJDK Assembly Exception [2].
 #
 # [1] https://www.gnu.org/software/classpath/license.html
-# [2] http://openjdk.java.net/legal/assembly-exception.html
+# [2] https://openjdk.org/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #################################################################################

--- a/openj9.build/scripts/openj9-systemtest-clone-make.bat
+++ b/openj9.build/scripts/openj9-systemtest-clone-make.bat
@@ -1,5 +1,5 @@
 REM *******************************************************************************
-REM Copyright (c) 2017, 2021 IBM Corp. and others
+REM Copyright (c) 2017, 2023 IBM Corp. and others
 REM
 REM This program and the accompanying materials are made available under the
 REM terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@ REM version 2 with the GNU Classpath Exception [1] and GNU General Public Licens
 REM version 2 with the OpenJDK Assembly Exception [2].
 REM
 REM [1] https://www.gnu.org/software/classpath/license.html
-REM [2] http://openjdk.java.net/legal/assembly-exception.html
+REM [2] https://openjdk.org/legal/assembly-exception.html
 REM
 REM SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 REM *******************************************************************************/

--- a/openj9.build/scripts/openj9-systemtest-clone-make.sh
+++ b/openj9.build/scripts/openj9-systemtest-clone-make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # -------------------------------------------------------------------------------
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@
 # version 2 with the OpenJDK Assembly Exception [2].
 #
 # [1] https://www.gnu.org/software/classpath/license.html
-# [2] http://openjdk.java.net/legal/assembly-exception.html
+# [2] https://openjdk.org/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 # -------------------------------------------------------------------------------

--- a/openj9.stf.extensions/build.xml
+++ b/openj9.stf.extensions/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2017, 2019 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/DummySleeper.java
+++ b/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/DummySleeper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/SharedClassesPluginInterface.java
+++ b/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/SharedClassesPluginInterface.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/StfSharedClassesExtension.java
+++ b/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/StfSharedClassesExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2021 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/.classpath
+++ b/openj9.test.daa/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.daa/build.xml
+++ b/openj9.test.daa/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2017, 2019 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.daa/src/test.daa/net/openj9/test/BasicTestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/BasicTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/LogParser.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/LogParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/MarshallingTestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/MarshallingTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/I2PD_PD2ITestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/I2PD_PD2ITestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/RandomTests.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/RandomTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/TestI2PD.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/TestI2PD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/TestPD2I.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/TestPD2I.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/TestPD2Primitives2PD.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PD2Primitive/TestPD2Primitives2PD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PDComparisonsTestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PDComparisonsTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PDMoveShifts/ShiftTestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PDMoveShifts/ShiftTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PDMoveShifts/TestPDMove.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PDMoveShifts/TestPDMove.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/PDMoveShifts/TestShiftsAndConvert.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/PDMoveShifts/TestShiftsAndConvert.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2022 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/TestGeneration.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/TestGeneration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/TestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/TestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/Utils.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/ArithmeticsTestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/ArithmeticsTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmeticComparisonBase.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmeticComparisonBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmeticInline.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmeticInline.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmeticOperations.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmeticOperations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmetics.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestArithmetics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestComparisonEquals.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestComparisonEquals.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestPDComparisons.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestPDComparisons.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestPerformance.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestPerformance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestSubExceptions.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestSubExceptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestValidityChecking.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/arithmetics/TestValidityChecking.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/LongIntegerComparison.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/LongIntegerComparison.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestBinaryConverters.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestBinaryConverters.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Double.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Double.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Float.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Float.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Integer.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Integer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2IntegerNumBytes.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2IntegerNumBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Long.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Long.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2LongNumBytes.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2LongNumBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Short.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2Short.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2ShortNumBytes.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestByteArray2ShortNumBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestDouble2ByteArray.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestDouble2ByteArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestFloat2ByteArray.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestFloat2ByteArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestInteger2ByteArray.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestInteger2ByteArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestInteger2ByteArrayNumBytes.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestInteger2ByteArrayNumBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestLong2ByteArray.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestLong2ByteArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestLong2ByteArrayNumBytes.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestLong2ByteArrayNumBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestOptimizer.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestOptimizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestShort2ByteArray.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestShort2ByteArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestShort2ByteArrayNumBytes.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/binaryData/TestShort2ByteArrayNumBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/DecimalTestBase.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/DecimalTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/DecimalTestRunner.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/DecimalTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestBD2PD2BD.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestBD2PD2BD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestDecimalData.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestDecimalData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestDecimalData2.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestDecimalData2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestED2PD.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestED2PD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestPD2ED.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestPD2ED.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2021 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestPD2UD.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestPD2UD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestUD2PD.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/decimals/TestUD2PD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.daa/src/test.daa/net/openj9/test/simple/ConvertDecimal.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/simple/ConvertDecimal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* (c) Copyright IBM Corp. 2017, 2017
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available
 * under the terms of the Eclipse Public License 2.0 which accompanies
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 *     [1] https://www.gnu.org/software/classpath/license.html
-*     [2] http://openjdk.java.net/legal/assembly-exception.html
+*     [2] https://openjdk.org/legal/assembly-exception.html
 *******************************************************************************/
 
 package net.openj9.test.simple;

--- a/openj9.test.daa/src/test.daa/net/openj9/test/simple/MarshalUnmarshalBinary.java
+++ b/openj9.test.daa/src/test.daa/net/openj9/test/simple/MarshalUnmarshalBinary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* (c) Copyright IBM Corp. 2017, 2017
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available
 * under the terms of the Eclipse Public License 2.0 which accompanies
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 *     [1] https://www.gnu.org/software/classpath/license.html
-*     [2] http://openjdk.java.net/legal/assembly-exception.html
+*     [2] https://openjdk.org/legal/assembly-exception.html
 *******************************************************************************/
 
 package net.openj9.test.simple;

--- a/openj9.test.jlm/.classpath
+++ b/openj9.test.jlm/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.jlm/build.xml
+++ b/openj9.test.jlm/build.xml
@@ -2,7 +2,7 @@
 
 <!--
 /*******************************************************************************
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -17,7 +17,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/Constants.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/GCExtensionCommand.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/GCExtensionCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/IBMBeanExtension.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/IBMBeanExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/MemoryExtensionCommand.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/MemoryExtensionCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/MemoryPoolExtensionCommand.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/MemoryPoolExtensionCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/OperatingSystemExtensionCommand.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/extensions/OperatingSystemExtensionCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2022 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmLocal.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmLocal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteClassAuth.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteClassAuth.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2020 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteClassNoAuth.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteClassNoAuth.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2020 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteMemoryAuth.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteMemoryAuth.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2020 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteMemoryNoAuth.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/TestIBMJlmRemoteMemoryNoAuth.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2020 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/local/VMLogger.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/local/VMLogger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/remote/ClassProfiler.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/remote/ClassProfiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/remote/MemoryProfiler.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/remote/MemoryProfiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/EnvironmentData.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/EnvironmentData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/MemoryData.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/MemoryData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/MemoryListener.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/MemoryListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/VMData.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/jlm/resources/VMData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/BusyThread.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/BusyThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/RandomNumber.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/RandomNumber.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/TestOperatingSystemMXBean.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/TestOperatingSystemMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/TestOperatingSystemMXBean_Local.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/TestOperatingSystemMXBean_Local.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2022 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 *
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/TestOperatingSystemMXBean_Remote.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/TestOperatingSystemMXBean_Remote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2022 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 *
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/Fork.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/Fork.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/Philosopher.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/Philosopher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/TestApplicationUserCpuTime.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/TestApplicationUserCpuTime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/TestJvmCpuMonitorMXBean_Local.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/TestJvmCpuMonitorMXBean_Local.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 * 
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/TestJvmCpuMonitorMXBean_Remote.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/TestJvmCpuMonitorMXBean_Remote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/ThreadCategory.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/management/jvmcpumonitorbean/ThreadCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/virtualization/GuestOSMXBeanTest_Local.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/virtualization/GuestOSMXBeanTest_Local.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/virtualization/GuestOSMXBeanTest_Remote.java
+++ b/openj9.test.jlm/src/test.jlm.ibm/net/openj9/test/virtualization/GuestOSMXBeanTest_Remote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corp. and others
+* Copyright (c) 2017, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.load/.classpath
+++ b/openj9.test.load/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.load/build.xml
+++ b/openj9.test.load/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2017, 2019 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2021 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.load/src/test.load/net/openj9/stf/HeapHogLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/HeapHogLoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2021 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.load/src/test.load/net/openj9/stf/ObjectTreeLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/ObjectTreeLoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2021 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses.jvmti/.classpath
+++ b/openj9.test.sharedClasses.jvmti/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.sharedClasses.jvmti/build.xml
+++ b/openj9.test.sharedClasses.jvmti/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.sharedClasses.jvmti/src/native/Makefile
+++ b/openj9.test.sharedClasses.jvmti/src/native/Makefile
@@ -1,5 +1,5 @@
 #################################################################################
-# Copyright (c) 2017, 2021 IBM Corp.
+# Copyright (c) 2017, 2023 IBM Corp.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 # version 2 with the OpenJDK Assembly Exception [2].
 #
 # [1] https://www.gnu.org/software/classpath/license.html
-# [2] http://openjdk.java.net/legal/assembly-exception.html
+# [2] https://openjdk.org/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #################################################################################

--- a/openj9.test.sharedClasses.jvmti/src/native/sharedClasses.c
+++ b/openj9.test.sharedClasses.jvmti/src/native/sharedClasses.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/sc/api/SharedClassesCacheChecker.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/sc/api/SharedClassesCacheChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2021 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2022 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/.classpath
+++ b/openj9.test.sharedClasses/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.sharedClasses/build.xml
+++ b/openj9.test.sharedClasses/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2017, 2021 IBM Corp.
+Copyright (c) 2017, 2023 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -15,7 +15,7 @@ version 2 with the GNU Classpath Exception [1] and GNU General Public License,
 version 2 with the OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.sharedClasses/docs/README.md
+++ b/openj9.test.sharedClasses/docs/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2021 IBM Corp. and others
+Copyright (c) 2017, 2023 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -15,7 +15,7 @@ Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
 [1] https://www.gnu.org/software/classpath/license.html
-[2] http://openjdk.java.net/legal/assembly-exception.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2020 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkload.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_Increase.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_Increase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_IncreaseDecrease.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_IncreaseDecrease.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2020 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_Increase_JitAot.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_Increase_JitAot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/JavaGen.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/JavaGen.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlave.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlave.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiCL.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiCL.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiJar.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiJar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiThread.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2020 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiThreadMultiCL.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiThreadMultiCL.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/SCSoftmxTestUtil.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/SCSoftmxTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2020 IBM Corp. and others
+* Copyright (c) 2016, 2023 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/classes/Dummy.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/classes/Dummy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2023 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -14,7 +14,7 @@
 * version 2 with the OpenJDK Assembly Exception [2].
 * 
 * [1] https://www.gnu.org/software/classpath/license.html
-* [2] http://openjdk.java.net/legal/assembly-exception.html
+* [2] https://openjdk.org/legal/assembly-exception.html
 *
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 *******************************************************************************/


### PR DESCRIPTION
See eclipse-openj9/openj9#16057.